### PR TITLE
updated vendor deps

### DIFF
--- a/glide.lock
+++ b/glide.lock
@@ -1,5 +1,5 @@
-hash: dc4a7a9bc86772d234c4e6be27cb97ec0ff37f083a90240142a4af1a49a487f1
-updated: 2017-03-24T15:53:53.249536017+01:00
+hash: dbdac267bfc7b46ff7081c77fc062d696e28da833cf998ecfa80cf012a2a89ca
+updated: 2017-03-30T15:51:16.192761239+02:00
 imports:
 - name: github.com/davecgh/go-spew
   version: 5215b55f46b2b919f50a1df0eaa5886afe4e3b3d
@@ -18,7 +18,7 @@ imports:
 - name: github.com/ghodss/yaml
   version: 73d445a93680fa1a78ae23a5839bad48f32ba1ee
 - name: github.com/giantswarm/clustertpr
-  version: 9767d94b67286d0003cb3a014b7e0cb94ef6e20f
+  version: 32e9d7b0551212e895cbd79c698dae9ae7b99cdd
   subpackages:
   - calico
   - cluster
@@ -28,6 +28,7 @@ imports:
   - docker/registry
   - etcd
   - flannel
+  - flannel/client
   - flannel/docker
   - kubernetes
   - kubernetes/api

--- a/glide.yaml
+++ b/glide.yaml
@@ -6,4 +6,4 @@ import:
   - pkg/api/unversioned
   - pkg/api/v1
 - package: github.com/giantswarm/clustertpr
-  version: 9767d94b67286d0003cb3a014b7e0cb94ef6e20f
+  version: 32e9d7b0551212e895cbd79c698dae9ae7b99cdd

--- a/vendor/github.com/giantswarm/clustertpr/flannel/client/client.go
+++ b/vendor/github.com/giantswarm/clustertpr/flannel/client/client.go
@@ -1,0 +1,5 @@
+package client
+
+type Client struct {
+	SubnetLen int
+}

--- a/vendor/github.com/giantswarm/clustertpr/flannel/flannel.go
+++ b/vendor/github.com/giantswarm/clustertpr/flannel/flannel.go
@@ -1,12 +1,15 @@
 package flannel
 
 import (
+	"github.com/giantswarm/clustertpr/flannel/client"
 	"github.com/giantswarm/clustertpr/flannel/docker"
 )
 
 type Flannel struct {
 	// Backend is the Flannel backend type, e.g. vxlan.
 	Backend string `json:"backend" yaml:"backend"`
+	// Client is the block for the flannel client configuration.
+	Client client.Client `json:"client" yaml:"client"`
 	// Docker is the block for the full Docker image tag.
 	Docker docker.Docker `json:"docker" yaml:"docker"`
 	// Interface is the network interface name, e.g. bond0.3, or ens33.


### PR DESCRIPTION
This PR goes towards https://github.com/giantswarm/kvm-operator/issues/59. Here we update changes from https://github.com/giantswarm/clustertpr/pull/6.