### PR TITLE
added package specific kind and version

### DIFF
--- a/kind.go
+++ b/kind.go
@@ -1,0 +1,6 @@
+package kvmtpr
+
+const (
+	// Kind is the TPR kind for kvmtpr resources.
+	Kind = "Kvm"
+)

--- a/version.go
+++ b/version.go
@@ -1,0 +1,6 @@
+package kvmtpr
+
+const (
+	// VersionV1 is the Kubernetes API version for v1 cluster resources.
+	VersionV1 = "kvm.cluster.giantswarm.io/v1"
+)


### PR DESCRIPTION
There are several TPR specific settings spread across repositories. See for instance https://github.com/giantswarm/kubernetesd/blob/5ed1b18f0cce6556b71f117a45430a25a615a3f4/service/creator/service.go#L23-L32. IMO the kinds and versions should be part of the TPR package itself. This PR provides this change. I will provide the same PR for the AWS TPR and for kubernetesd where the changes will be applied to improve the situation. 