### PR TITLE
Add PluralKind for use in resource URLs

### DIFF
--- a/kind.go
+++ b/kind.go
@@ -5,5 +5,5 @@ const (
 	Kind = "Kvm"
 
 	// PluralKind is the plural TPR kind for use in resource URLs.
-	PluralKind = "Kvms"
+	PluralKind = "kvms"
 )


### PR DESCRIPTION
This PR adds the plural kind. This is needed because the plural of aws is awses which is irregular.