### PR TITLE
Fix TPR version which doesn’t have the kvm prefix

### DIFF
--- a/version.go
+++ b/version.go
@@ -2,5 +2,5 @@ package kvmtpr
 
 const (
 	// VersionV1 is the Kubernetes API version for v1 cluster resources.
-	VersionV1 = "kvm.cluster.giantswarm.io/v1"
+	VersionV1 = "cluster.giantswarm.io/v1"
 )


### PR DESCRIPTION
Fixes problem with the TPR version which is weird and doesn't have the kvm prefix.