### PR TITLE
remove certctl block due to cert-operator usage

### DIFF
--- a/kvm/certctl/certctl.go
+++ b/kvm/certctl/certctl.go
@@ -1,9 +1,0 @@
-package certctl
-
-import (
-	"github.com/giantswarm/kvmtpr/kvm/certctl/docker"
-)
-
-type Certctl struct {
-	Docker docker.Docker `json:"docker" yaml:"docker"`
-}

--- a/kvm/certctl/docker/docker.go
+++ b/kvm/certctl/docker/docker.go
@@ -1,5 +1,0 @@
-package docker
-
-type Docker struct {
-	Image string `json:"image" yaml:"image"`
-}

--- a/kvm/kvm.go
+++ b/kvm/kvm.go
@@ -1,7 +1,6 @@
 package kvm
 
 import (
-	"github.com/giantswarm/kvmtpr/kvm/certctl"
 	"github.com/giantswarm/kvmtpr/kvm/endpointupdater"
 	"github.com/giantswarm/kvmtpr/kvm/k8skvm"
 	"github.com/giantswarm/kvmtpr/kvm/kubectl"
@@ -9,7 +8,6 @@ import (
 )
 
 type KVM struct {
-	Certctl         certctl.Certctl                 `json:"certctl" yaml:"certctl"`
 	EndpointUpdater endpointupdater.EndpointUpdater `json:"endpointUpdater" yaml:"endpointUpdater"`
 	K8sKVM          k8skvm.K8sKVM                   `json:"k8sKVM" yaml:"k8sKVM"`
 	Kubectl         kubectl.Kubectl                 `json:"kubectl" yaml:"kubectl"`


### PR DESCRIPTION
Towards https://github.com/giantswarm/giantswarm/issues/1197. I am going to use certificates issued by cert-operator in the next steps. I cleanup now because the kvm-operator doesn't do anything anyway at the moment. 